### PR TITLE
don't allow expanded arsenal stacking

### DIFF
--- a/TabletopTweaks/Bugfixes/Features/MythicFeats.cs
+++ b/TabletopTweaks/Bugfixes/Features/MythicFeats.cs
@@ -1,7 +1,15 @@
 ﻿using HarmonyLib;
 using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes.Prerequisites;
+using Kingmaker.Blueprints.Classes.Spells;
+using Kingmaker.Blueprints.Facts;
 using Kingmaker.Blueprints.JsonSystem;
+using Kingmaker.Designers.Mechanics.Facts;
+using Kingmaker.Enums;
+using Kingmaker.RuleSystem.Rules.Abilities;
+using Kingmaker.UnitLogic;
+using Kingmaker.UnitLogic.Parts;
+using System.Linq;
 using TabletopTweaks.Config;
 using TabletopTweaks.Extensions;
 using TabletopTweaks.Utilities;
@@ -34,6 +42,40 @@ namespace TabletopTweaks.Bugfixes.Features {
                         p.m_Feature = FeatTools.Selections.ExtraFeatMythicFeat.ToReference<BlueprintFeatureReference>();
                     }
                 );
+            }
+        }
+        [HarmonyPatch(typeof(SpellFocusParametrized), "OnEventAboutToTrigger", new[] { typeof(RuleCalculateAbilityParams) })]
+        static class SpellFocusParametrized_OnEventAboutToTrigger_ExpandedArsenal {
+            const string SpellFocusGuid = "";
+            const string SpellFocusGreaterGuid = "";
+            const ModifierDescriptor SpellFocusDescriptor = (ModifierDescriptor)1000;
+            const ModifierDescriptor SpellFocusGreaterDescriptor = (ModifierDescriptor)1001;
+            static bool Prefix(SpellFocusParametrized __instance, RuleCalculateAbilityParams evt) {
+                if (ModSettings.Fixes.MythicFeats.IsDisabled("ExpandedArsenal")) { return true; }
+                if (__instance.SpellsOnly && evt.Spellbook == null) { return true; }
+                var school = evt.Spell?.GetComponent<SpellComponent>()?.School ?? SpellSchool.None;
+                bool applyBonus = false;
+                if (!applyBonus) {
+                    // is this spell the right school
+                    applyBonus = school == __instance.Param;
+                }
+                if (!applyBonus) {
+                    // is expanded arsenal selected for this school
+                    applyBonus = __instance.Owner.Get<UnitPartExpandedArsenal>()?.HasSpellSchoolEntry(school) ?? false;
+                }
+                if (applyBonus) {
+                    var hasMythicFocus = evt.Initiator.Progression.Features.Enumerable.Any((Feature p) => p.Param == __instance.Param && p.Blueprint == __instance.MythicFocus);
+                    var bonus = __instance.BonusDC * (hasMythicFocus ? 2 : 1);
+                    // pick a non-stacking descriptor
+                    var descriptor = __instance.Fact.Blueprint.AssetGuid.ToString() switch {
+                               SpellFocusGuid => SpellFocusDescriptor,
+                        SpellFocusGreaterGuid => SpellFocusGreaterDescriptor,
+                                            _ => __instance.Descriptor
+                    };
+                    evt.AddBonusDC(bonus, descriptor);
+                }
+
+                return false;
             }
         }
     }

--- a/TabletopTweaks/Config/Fixes.json
+++ b/TabletopTweaks/Config/Fixes.json
@@ -815,6 +815,11 @@
         "Enabled": true,
         "Homebrew": false,
         "Description": "Can no longer be picked more than once."
+      },
+      "ExpandedArsenal": {
+        "Enabled": true,
+        "Homebrew": false,
+        "Description": "Can no longer stack multiple schools."
       }
     },
     "IsExpanded": true


### PR DESCRIPTION
this works by making Spell Focus and Greater Spell Focus each a non-stacking typed bonus

I couldn't be bothered to find and add the guids for spell focus and greater spell focus, but the concept should work

nb: I personally think these should stack, considering how high enemy saves are