### PR TITLE
Angel Sun Marked buff no longer makes a separate attack

### DIFF
--- a/TabletopTweaks-Base/Bugfixes/Abilities/Spells.cs
+++ b/TabletopTweaks-Base/Bugfixes/Abilities/Spells.cs
@@ -62,6 +62,7 @@ namespace TabletopTweaks.Base.Bugfixes.Abilities {
                 PatchDispelMagicGreater();
                 PatchEyeOfTheSun();
                 PatchFirebrand();
+                PatchSunMarked();
                 PatchFlamestrike();
                 PatchFrightfulAspect();
                 PatchGeniekind();
@@ -424,6 +425,29 @@ namespace TabletopTweaks.Base.Bugfixes.Abilities {
                     };
                 });
                 TTTContext.Logger.LogPatch("Patched", FirebrandBuff);
+            }
+
+            static void PatchSunMarked() {
+                if (Main.TTTContext.Fixes.Spells.IsDisabled("SunMarked")) { return; }
+
+                var AngelSunMarkedBuff = BlueprintTools.GetBlueprint<BlueprintBuff>("35407948549e61f4c80e6b59633d82b0");
+
+                AngelSunMarkedBuff.RemoveComponents<AddInitiatorAttackWithWeaponTrigger>();
+                AngelSunMarkedBuff.AddComponent<AddAdditionalWeaponDamage>(c => {
+                    c.Value = new ContextDiceValue() {
+                        DiceType = DiceType.D6,
+                        DiceCountValue = new ContextValue() {
+                            ValueType=ContextValueType.Rank,
+                            ValueRank=AbilityRankType.DamageDice,
+                        },
+                        BonusValue = 0
+                    };
+                    c.DamageType = new DamageTypeDescription() {
+                        Type = DamageType.Energy,
+                        Energy = DamageEnergyType.Holy
+                    };
+                });
+                TTTContext.Logger.LogPatch("Patched", AngelSunMarkedBuff);
             }
 
             static void PatchFlamestrike() {

--- a/TabletopTweaks-Base/Config/Fixes.json
+++ b/TabletopTweaks-Base/Config/Fixes.json
@@ -1133,6 +1133,11 @@
         "Homebrew": false,
         "Description": "Firebrand no longer causes excessive damage instances to trigger when attacking."
       },
+      "SunMarked": {
+        "Enabled": true,
+        "Homebrew": false,
+        "Description": "Sun Marked no longer causes excessive damage instances to trigger when attacking."
+      },
       "FixSpellFlags": {
         "Enabled": true,
         "Homebrew": false,


### PR DESCRIPTION
Similar problem to Firebrand spell: buff makes separate attack, receives extra damage rolls from bane, holy, etc.

Similar solution: swap `AddInitiatorAttackWithWeaponTrigger` component with `AddAdditionalWeaponDamage` component.