### PR TITLE
speed up FixFeatSelections patch

### DIFF
--- a/TabletopTweaks-Base/Bugfixes/General/FeatSelections.cs
+++ b/TabletopTweaks-Base/Bugfixes/General/FeatSelections.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes.Selection;
 using Kingmaker.Blueprints.JsonSystem;
 using Kingmaker.Utility;
@@ -26,11 +27,29 @@ namespace TabletopTweaks.Base.Bugfixes.General {
                     foreach (var feat in allFeats.Where(f => f.Get() is not null)) {
                         FeatTools.Selections.FeatSelections
                             .Where(selection => feat.Get().HasGroup(selection.Group) || feat.Get().HasGroup(selection.Group2))
-                            .ForEach(selection => selection.AddFeatures(feat));
+                            .ForEach(selection => AddFeaturesNoSort(selection, feat));
                     }
+                    FeatTools.Selections.FeatSelections.ForEach(x => SortFeatures(x));
                     var ArcaneDiscoverySelection = BlueprintTools.GetModBlueprint<BlueprintFeatureSelection>(TTTContext, "ArcaneDiscoverySelection");
                     FeatTools.Selections.LoremasterWizardFeatSelection.RemoveFeatures(ArcaneDiscoverySelection);
                 }
+            }
+
+            private static void AddFeaturesNoSort(BlueprintFeatureSelection selection, params BlueprintFeatureReference[] features) {
+                foreach (BlueprintFeatureReference value in features) {
+                    if (!Enumerable.Contains(selection.m_AllFeatures, value)) {
+                        selection.m_AllFeatures = selection.m_AllFeatures.AppendToArray(value);
+                    }
+
+                    if (!Enumerable.Contains(selection.m_Features, value)) {
+                        selection.m_Features = selection.m_Features.AppendToArray(value);
+                    }
+                }
+            }
+
+            private static void SortFeatures(BlueprintFeatureSelection selection) {
+                selection.m_AllFeatures = selection.m_AllFeatures.OrderBy(feature => feature?.Get()?.Name ?? feature?.Get()?.name).ToArray();
+                selection.m_Features = selection.m_Features.OrderBy(feature => feature?.Get()?.Name ?? feature?.Get()?.name).ToArray();
             }
         }
     }


### PR DESCRIPTION
Sorting m_Features and m_AllFeatures on each addition really adds up.
That patch takes ~1.5 seconds normally on my machine, and with this improvement it's below 0.1s. Cutting down total load time from ~17 seconds to 15+.
