### PR TITLE
Wizard - hand of the apprentice target fix

### DIFF
--- a/TabletopTweaks-Base/Bugfixes/Classes/Wizard.cs
+++ b/TabletopTweaks-Base/Bugfixes/Classes/Wizard.cs
@@ -1,9 +1,10 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.JsonSystem;
 using Kingmaker.Utility;
 using System.Linq;
 using TabletopTweaks.Core.Utilities;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
 using static TabletopTweaks.Base.Main;
 
 namespace TabletopTweaks.Base.Bugfixes.Classes {
@@ -39,6 +40,31 @@ namespace TabletopTweaks.Base.Bugfixes.Classes {
                 Initialized = true;
                 TTTContext.Logger.LogHeader("Patching Wizard");
 
+                PatchHandOfTheApprentice();
+            }
+
+            static void PatchHandOfTheApprentice() {
+                if (Main.TTTContext.Fixes.Wizard.Base.IsDisabled("HandOfTheApprentice")) { return; }
+
+                string[] handOfTheApprenticeGUIDs = new string[] {
+                    "864146bb3e41e3644b18e1ee4cc26acf", // Capacité à volonté
+                    "38aab7423d96de84d8e6ab2cdbccce63"  // Seconde capacité
+                };
+
+                foreach (var guid in handOfTheApprenticeGUIDs) {
+                    var Ability = BlueprintTools.GetBlueprint<BlueprintAbility>(guid);
+
+                    if (Ability != null) {
+                        Ability.TemporaryContext(bp => {
+                            bp.CanTargetFriends = false;
+                            bp.CanTargetEnemies = true;
+                            bp.CanTargetPoint = false;
+                            bp.CanTargetSelf = false;
+
+                            TTTContext.Logger.LogPatch("Patched HandOfTheApprentice (Wizard)", bp);
+                        });
+                    }
+                }
             }
         }
     }

--- a/TabletopTweaks-Base/Config/Bugfixes.cs
+++ b/TabletopTweaks-Base/Config/Bugfixes.cs
@@ -1,4 +1,4 @@
-﻿using Kingmaker.Utility;
+using Kingmaker.Utility;
 using System;
 using System.Collections.Generic;
 using TabletopTweaks.Core.Config;
@@ -36,6 +36,7 @@ namespace TabletopTweaks.Base.Config {
         public ClassGroup Sorcerer = new ClassGroup();
         public ClassGroup Warpriest = new ClassGroup();
         public ClassGroup Witch = new ClassGroup();
+        public ClassGroup Wizard = new ClassGroup();
         public SettingGroup EldritchKnight = new SettingGroup();
         public SettingGroup Hellknight = new SettingGroup();
         public SettingGroup Loremaster = new SettingGroup();
@@ -75,7 +76,7 @@ namespace TabletopTweaks.Base.Config {
             Sorcerer.SetParents();
             Warpriest.SetParents();
             Witch.SetParents();
-
+            Wizard.SetParents();
             Units.SetParents();
             Crusade.SetParents();
             Items.SetParents();
@@ -117,6 +118,7 @@ namespace TabletopTweaks.Base.Config {
             Sorcerer.LoadClassGroup(loadedSettings.Sorcerer, NewSettingsOffByDefault);
             Warpriest.LoadClassGroup(loadedSettings.Warpriest, NewSettingsOffByDefault);
             Witch.LoadClassGroup(loadedSettings.Witch, NewSettingsOffByDefault);
+            Wizard.LoadClassGroup(loadedSettings.Wizard, NewSettingsOffByDefault);
 
             EldritchKnight.LoadSettingGroup(loadedSettings.EldritchKnight, NewSettingsOffByDefault);
             Hellknight.LoadSettingGroup(loadedSettings.Hellknight, NewSettingsOffByDefault);

--- a/TabletopTweaks-Base/Config/Fixes.json
+++ b/TabletopTweaks-Base/Config/Fixes.json
@@ -1207,6 +1207,21 @@
     },
     "Archetypes": {}
   },
+  "Wizard": {
+    "DisableAll": false,
+    "Base": {
+      "DisableAll": false,
+      "Settings": {
+        "HandOfTheApprentice": {
+          "Enabled": true,
+          "Homebrew": false,
+          "Description": "Fixes Hand of the Apprentice to only target enemies."
+        }
+      },
+      "IsExpanded": true
+    },
+    "Archetypes": {}
+  },
   "EldritchKnight": {
     "DisableAll": false,
     "Settings": {

--- a/TabletopTweaks-Base/UMMSettingsUI.cs
+++ b/TabletopTweaks-Base/UMMSettingsUI.cs
@@ -1,4 +1,4 @@
-﻿using TabletopTweaks.Core.UMMTools;
+using TabletopTweaks.Core.UMMTools;
 using UnityModManagerNet;
 
 namespace TabletopTweaks.Base {
@@ -117,6 +117,10 @@ namespace TabletopTweaks.Base {
                 SetttingUI.NestedSettingGroup("Witch", TabLevel, Fixes.Witch,
                     ("Base", Fixes.Witch.Base),
                     Fixes.Witch.Archetypes
+                );
+                SetttingUI.NestedSettingGroup("Wizard", TabLevel, Fixes.Wizard,
+                    ("Base", Fixes.Wizard.Base),
+                    Fixes.Wizard.Archetypes
                 );
                 SetttingUI.SettingGroup("Eldritch Knight", TabLevel, Fixes.EldritchKnight);
                 SetttingUI.SettingGroup("Hellknight", TabLevel, Fixes.Hellknight);


### PR DESCRIPTION
In the base game, the Universalist wizard ability Hand of the apprentice only target an ally instead of an enemy. Fixed this behaviour.